### PR TITLE
Phase 2: system font stack + extract Bauhaus IIFE

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           mkdir -p _site/.well-known
           # Copy only files needed at runtime; exclude tooling, lockfiles, docs
-          cp index.html manifest.json sitemap.xml robots.txt CNAME humans.txt _site/
+          cp index.html manifest.json sitemap.xml robots.txt CNAME humans.txt bauhaus.js _site/
           cp favicon.png icon-192.png icon-512.png og-image.png _site/
           cp .well-known/security.txt _site/.well-known/
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Stage site assets
         run: |
           mkdir -p _site/.well-known
-          cp index.html manifest.json sitemap.xml robots.txt CNAME humans.txt _site/
+          cp index.html manifest.json sitemap.xml robots.txt CNAME humans.txt bauhaus.js _site/
           cp favicon.png icon-192.png icon-512.png og-image.png _site/
           cp .well-known/security.txt _site/.well-known/
 

--- a/bauhaus.js
+++ b/bauhaus.js
@@ -1,0 +1,68 @@
+(function () {
+  var API = 'https://bauhaus.cascadiacollections.workers.dev/api';
+  var CACHE_LOAD_MS = 50;
+  var now = new Date();
+  var pad = function (n) {
+    return n < 10 ? '0' + n : '' + n;
+  };
+  var today = now.getFullYear() + '-' + pad(now.getMonth() + 1) + '-' + pad(now.getDate());
+  var dateParam = '?d=' + today;
+  var bg = document.getElementById('bg');
+  var attribution = document.getElementById('attribution');
+
+  var attrLink = document.createElement('a');
+  attrLink.href = 'https://github.com/cascadiacollections/bauhaus';
+  attrLink.target = '_blank';
+  attrLink.rel = 'noopener noreferrer';
+  attrLink.textContent = '🎨 bauhaus';
+  attribution.appendChild(attrLink);
+
+  function updateAttribution(title) {
+    attrLink.textContent = '🎨 ' + title;
+  }
+
+  var loadStart = Date.now();
+  var img = new Image();
+  img.onload = function () {
+    bg.style.backgroundImage = 'url(' + img.src + ')';
+    if (Date.now() - loadStart < CACHE_LOAD_MS) {
+      bg.style.transition = 'none';
+    }
+    bg.classList.add('loaded');
+  };
+  img.onerror = function () {
+    bg.parentNode.removeChild(bg);
+    attribution.parentNode.removeChild(attribution);
+  };
+  img.src = API + '/today' + dateParam;
+
+  try {
+    var cachedDate = localStorage.getItem('bg-date');
+    var cachedTitle = localStorage.getItem('bg-title');
+    if (cachedDate === today && cachedTitle) {
+      updateAttribution(cachedTitle);
+      return;
+    }
+  } catch (_e) {
+    /* localStorage unavailable */
+  }
+
+  fetch(API + '/today.json' + dateParam)
+    .then(function (r) {
+      return r.json();
+    })
+    .then(function (data) {
+      if (data && data.title) {
+        try {
+          localStorage.setItem('bg-date', today);
+          localStorage.setItem('bg-title', data.title);
+        } catch (_e) {
+          /* localStorage unavailable */
+        }
+        updateAttribution(data.title);
+      }
+    })
+    .catch(function () {
+      /* attribution is non-critical */
+    });
+})();

--- a/index.html
+++ b/index.html
@@ -2,13 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://bauhaus.cascadiacollections.workers.dev" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300..700&display=swap"
-    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
@@ -24,7 +18,7 @@
     <!-- Security headers (GitHub Pages cannot deliver server headers; meta covers what it can) -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://bauhaus.cascadiacollections.workers.dev https://www.google-analytics.com data:; connect-src 'self' https://bauhaus.cascadiacollections.workers.dev https://www.google-analytics.com; object-src 'none'; base-uri 'self'"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://bauhaus.cascadiacollections.workers.dev https://www.google-analytics.com data:; connect-src 'self' https://bauhaus.cascadiacollections.workers.dev https://www.google-analytics.com; object-src 'none'; base-uri 'self'"
     />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
@@ -79,9 +73,12 @@
 
       body {
         font-family:
-          'Plus Jakarta Sans',
           system-ui,
           -apple-system,
+          'Segoe UI',
+          Roboto,
+          'Helvetica Neue',
+          Arial,
           sans-serif;
         line-height: 1.5;
         -webkit-font-smoothing: antialiased;
@@ -361,76 +358,7 @@
       </nav>
     </main>
     <footer id="attribution" class="attribution"></footer>
-    <script>
-      (function () {
-        var API = 'https://bauhaus.cascadiacollections.workers.dev/api';
-        var CACHE_LOAD_MS = 50;
-        var now = new Date();
-        var pad = function (n) {
-          return n < 10 ? '0' + n : '' + n;
-        };
-        var today = now.getFullYear() + '-' + pad(now.getMonth() + 1) + '-' + pad(now.getDate());
-        var dateParam = '?d=' + today;
-        var bg = document.getElementById('bg');
-        var attribution = document.getElementById('attribution');
-
-        var attrLink = document.createElement('a');
-        attrLink.href = 'https://github.com/cascadiacollections/bauhaus';
-        attrLink.target = '_blank';
-        attrLink.rel = 'noopener noreferrer';
-        attrLink.textContent = '🎨 bauhaus';
-        attribution.appendChild(attrLink);
-
-        function updateAttribution(title) {
-          attrLink.textContent = '🎨 ' + title;
-        }
-
-        var loadStart = Date.now();
-        var img = new Image();
-        img.onload = function () {
-          bg.style.backgroundImage = 'url(' + img.src + ')';
-          if (Date.now() - loadStart < CACHE_LOAD_MS) {
-            bg.style.transition = 'none';
-          }
-          bg.classList.add('loaded');
-        };
-        img.onerror = function () {
-          bg.parentNode.removeChild(bg);
-          attribution.parentNode.removeChild(attribution);
-        };
-        img.src = API + '/today' + dateParam;
-
-        try {
-          var cachedDate = localStorage.getItem('bg-date');
-          var cachedTitle = localStorage.getItem('bg-title');
-          if (cachedDate === today && cachedTitle) {
-            updateAttribution(cachedTitle);
-            return;
-          }
-        } catch (_e) {
-          /* localStorage unavailable */
-        }
-
-        fetch(API + '/today.json' + dateParam)
-          .then(function (r) {
-            return r.json();
-          })
-          .then(function (data) {
-            if (data && data.title) {
-              try {
-                localStorage.setItem('bg-date', today);
-                localStorage.setItem('bg-title', data.title);
-              } catch (_e) {
-                /* localStorage unavailable */
-              }
-              updateAttribution(data.title);
-            }
-          })
-          .catch(function () {
-            /* attribution is non-critical */
-          });
-      })();
-    </script>
+    <script src="/bauhaus.js" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",


### PR DESCRIPTION
## Summary

Phase 2 polish from the roadmap (plan.md). Merges the highest-leverage perf wins that don't depend on external services.

### Changes
- **Font strategy**: drop Google Fonts entirely. Switch to system font stack (`system-ui, -apple-system, 'Segoe UI', Roboto, ...`). Removes 2 preconnects + 1 render-blocking stylesheet from critical path. Saves ~3 RTTs and ~30KB on first paint.
- **Extract Bauhaus IIFE** to `/bauhaus.js` (deferred). Reduces inline JS surface and sets up future CSP tightening once GA is replaced (Phase 4).
- **CSP cleanup**: drop `fonts.googleapis.com` and `fonts.gstatic.com` allowances since fonts are now system-only.
- Stage `bauhaus.js` in both deploy and Lighthouse pipelines.

### Verification
- Lighthouse CI gates (perf ≥0.9, a11y ≥0.95, BP ≥0.9, SEO ≥0.95) should now pass with more headroom.
- Visual: page should look identical on macOS/iOS (system-ui resolves to SF Pro, very close to Plus Jakarta Sans).

### Notes
- `'unsafe-inline'` remains on `script-src` because GA bootstrap is still inline. Will be removed in Phase 4 when GA → Cloudflare Web Analytics swap lands.

Roadmap: see `plan.md` (session artifact).