### PR TITLE
Fix stale background image cache in Edge

### DIFF
--- a/bauhaus.js
+++ b/bauhaus.js
@@ -33,7 +33,7 @@
     attribution.parentNode.removeChild(attribution);
   };
   bg.crossOrigin = 'anonymous';
-  bg.src = API + '/today';
+  bg.src = API + '/today' + dateParam;
 
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', function () {


### PR DESCRIPTION
## Summary\n- append the daily date query to the background image request\n- ensure service-worker cache keys rotate by day instead of reusing a single `/api/today` key\n\n## Why\nSome long-lived Edge profiles could remain stuck on stale/broken cached image responses for `/api/today`. Using the same daily query key already used by the metadata fetch keeps attribution/image in sync and forces regular cache turnover.