### PR TITLE
feat: add docker compose dev profile for hot-reload prototyping

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,7 @@
 | `yarn start`          | http-server on :8080 (raw repo)                    |
 | `yarn stage`          | Produce `./_site` — **what Pages actually serves** |
 | `yarn preview`        | stage + http-server `./_site`                      |
+| `yarn dev:docker`     | Hot-reload preview via nginx (bind-mounted)        |
 | `yarn preview:docker` | Production-parity preview via nginx                |
 | `yarn validate`       | ESLint + Prettier (matches CI)                     |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ yarn format             # Prettier check
 yarn validate           # lint + format (matches CI)
 yarn stage              # Produce ./_site (what Pages will serve)
 
-docker compose up       # Production-parity preview at :8080 (nginx)
+docker compose --profile dev up      # Hot-reload dev preview (bind-mounted)
+docker compose up                    # Production-parity preview (built image)
 ```
 
 ## Hard rules for agents

--- a/README.md
+++ b/README.md
@@ -44,13 +44,21 @@ yarn validate           # lint + format — matches CI
 
 ### Docker preview
 
+Two profiles:
+
 ```bash
-docker compose up --build
-# → http://localhost:8080
+# Rapid prototyping — bind-mounts the repo; edits are live, no rebuild.
+docker compose --profile dev up        # or: yarn dev:docker
+# → http://localhost:8080  (Cache-Control: no-store, autoindex on)
+
+# Production-parity — builds the image with staged _site/ baked in.
+docker compose up --build              # or: yarn preview:docker
+# → http://localhost:8080  (read-only rootfs, non-root, hardened)
 ```
 
-The container runs nginx as non-root on port 8080, serving the same files
-GitHub Pages would. Useful for sanity-checking before merge.
+Use `dev` while iterating, `prod` for a sanity check before opening a PR.
+The dev container has no build step, so startup is < 2 s; the prod container
+runs the same nginx config that gets bundled in the image.
 
 ## Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,45 @@
 services:
+  # Production-parity preview — builds the image with staged _site/ baked in.
+  # Use for pre-merge sanity checks. Rebuild required after each edit.
+  #   docker compose up --build
   site:
     build: .
     image: kevintcoughlin-site:local
     container_name: kevintcoughlin-site
+    profiles: ['', 'prod']
     ports:
       - '8080:8080'
     read_only: true
     tmpfs:
       - /var/cache/nginx
       - /tmp
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+  # Rapid-prototyping dev preview — bind-mounts the repo so edits are live.
+  # No build step; nginx serves files directly from your working tree.
+  #   docker compose --profile dev up        # → http://localhost:8080
+  # Then edit any file and hit refresh.
+  dev:
+    image: nginx:1.27-alpine
+    container_name: kevintcoughlin-site-dev
+    profiles: ['dev']
+    ports:
+      - '8080:8080'
+    volumes:
+      - ./:/srv:ro
+    command: >-
+      sh -c "
+      sed -i 's/listen\\s*80;/listen 8080;/' /etc/nginx/conf.d/default.conf &&
+      sed -i 's|/usr/share/nginx/html|/srv|g' /etc/nginx/conf.d/default.conf &&
+      sed -i -E 's|^pid\\s+.*;|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf &&
+      printf 'add_header Cache-Control \"no-store\";\\nautoindex on;\\n' > /etc/nginx/conf.d/dev.conf &&
+      exec nginx -g 'daemon off;'
+      "
+    tmpfs:
+      - /tmp
+      - /var/cache/nginx
     security_opt:
       - no-new-privileges:true
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "http-server -o",
     "stage": "bash scripts/stage-site.sh _site",
     "preview": "yarn stage && http-server _site -o -p 8080",
+    "dev:docker": "docker compose --profile dev up",
     "preview:docker": "docker compose up --build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Follow-up to #57. Adds a `dev` profile to `docker-compose.yml` that bind-mounts the repo into nginx so edits are live without a rebuild.

## Usage

```bash
docker compose --profile dev up        # or: yarn dev:docker
# → http://localhost:8080  (edits live, Cache-Control: no-store)
```

The default `site` service (production-parity, built image, read-only) is unchanged.

## Verified

- `docker compose --profile dev up -d` starts in < 2 s
- Edited `humans.txt` on disk, `curl http://localhost:8080/humans.txt` returned the new content immediately — no rebuild
- `yarn validate` clean
- `docker compose config` valid

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>