### PR TITLE
feat: add Codespaces prebuild workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Kevin Coughlin Personal Website",
-  "image": "ghcr.io/kevintcoughlin/kevintcoughlin.github.io/devcontainer:latest",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
 
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,6 @@
 {
   "name": "Kevin Coughlin Personal Website",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
+  "image": "ghcr.io/kevintcoughlin/kevintcoughlin.github.io/devcontainer:latest",
 
   "customizations": {
     "vscode": {

--- a/.github/workflows/codespaces-prebuild.yml
+++ b/.github/workflows/codespaces-prebuild.yml
@@ -1,0 +1,34 @@
+name: Codespaces Prebuilds
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 8 * * 1" # Weekly Monday rebuild
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pre-build devcontainer image
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository }}/devcontainer
+          cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+          push: filter
+          refFilterForPush: refs/heads/master

--- a/.github/workflows/codespaces-prebuild.yml
+++ b/.github/workflows/codespaces-prebuild.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron: "0 8 * * 1" # Weekly Monday rebuild
   workflow_dispatch:
@@ -16,7 +19,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -28,7 +31,7 @@ jobs:
       - name: Pre-build devcontainer image
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/${{ github.repository }}/devcontainer
-          cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+          imageName: ghcr.io/kevintcoughlin/kevintcoughlin.github.io/devcontainer
+          cacheFrom: ghcr.io/kevintcoughlin/kevintcoughlin.github.io/devcontainer
           push: filter
           refFilterForPush: refs/heads/master


### PR DESCRIPTION
## Summary

Sets up a Codespaces prebuild so new Codespaces open faster by pulling a pre-built devcontainer image from GHCR instead of building the Dockerfile locally.

## Changes

- **`.github/workflows/codespaces-prebuild.yml`** — new workflow using `devcontainers/ci@v0.3`
  - Triggers on push to `master`, weekly Monday cron (08:00 UTC), and `workflow_dispatch`
  - Builds and pushes the devcontainer image to `ghcr.io/kevintcoughlin/kevintcoughlin.github.io/devcontainer`
  - Uses `cacheFrom` so only changed layers are rebuilt
  - Only pushes on `refs/heads/master` (PRs build without pushing)

- **`.devcontainer/devcontainer.json`** — swap `build.dockerfile` for `image` pointing to the prebuilt GHCR image

## Notes

- No extra secrets needed — `GITHUB_TOKEN` already has `packages: write` on public repos
- `Dockerfile` remains in place; `devcontainers/ci` uses it to build the image
- `postCreateCommand` (`yarn install --immutable`) still runs, but the Docker build step is eliminated at Codespace creation time