### PR TITLE
chore(ci): align cron quoting with Prettier YAML output

### DIFF
--- a/.github/workflows/codespaces-prebuild.yml
+++ b/.github/workflows/codespaces-prebuild.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: "0 8 * * 1" # Weekly Monday rebuild
+    - cron: '0 8 * * 1' # Weekly Monday rebuild
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes the workflow formatting issue that broke `yarn format` in CI. The only change is aligning the cron expression quoting in `codespaces-prebuild.yml` with Prettier's YAML output.

## Type

- [ ] feat — user-visible behaviour change
- [x] fix — bug fix
- [ ] chore(deps) — dependency bump
- [x] chore(ci) — workflow / Actions change
- [ ] docs — README / AGENTS.md / inline comments only
- [ ] perf / a11y / SEO

## Verification

- [x] `yarn validate` passes locally
- [ ] `yarn stage && ls _site/` includes any new runtime files
- [ ] Lighthouse CI thresholds (perf ≥ 90, a11y ≥ 95) not regressed
- [ ] CSP in `index.html` updated if a new external origin was added
- [ ] Tested at <http://localhost:8080> via `yarn start` or `docker compose up`

## Notes for reviewers

N/A