### PR TITLE
fix: open hyperlinks in same tab

### DIFF
--- a/bauhaus.js
+++ b/bauhaus.js
@@ -12,7 +12,6 @@
 
   var attrLink = document.createElement('a');
   attrLink.href = 'https://github.com/cascadiacollections/bauhaus';
-  attrLink.target = '_blank';
   attrLink.rel = 'noopener noreferrer';
   attrLink.textContent = '🎨 bauhaus';
   attribution.appendChild(attrLink);

--- a/index.html
+++ b/index.html
@@ -331,7 +331,6 @@
           <li>
             <a
               href="https://github.com/KevinTCoughlin"
-              target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub profile"
               >github.com</a
@@ -340,7 +339,6 @@
           <li>
             <a
               href="https://www.linkedin.com/in/kevintcoughlin"
-              target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn profile"
               >linkedin.com</a
@@ -349,7 +347,6 @@
           <li>
             <a
               href="https://twitter.com/kevintcoughlin"
-              target="_blank"
               rel="noopener noreferrer"
               aria-label="X profile"
               >x.com</a
@@ -360,7 +357,6 @@
           <span class="fp-label">pgp:</span>
           <a
             href="https://keyoxide.org/5261704E7C5C2D39F49786C1F94A3D5EBF8567C4"
-            target="_blank"
             rel="noopener noreferrer me"
             aria-label="5261 704E 7C5C 2D39 F497 86C1 F94A 3D5E BF85 67C4 — PGP key on Keyoxide"
           >


### PR DESCRIPTION
## Summary\n- remove `target="_blank"` from profile links in `index.html`\n- remove dynamic `_blank` target from bauhaus attribution link in `bauhaus.js`\n- keep links opening in the same tab across the site\n\n## Testing\n- yarn validate --quiet